### PR TITLE
Removing the web.py dependencies

### DIFF
--- a/log.py
+++ b/log.py
@@ -37,7 +37,7 @@ class Log:
     '''
     @staticmethod
     def setup(_filename = None, _loglevel = logging.DEBUG):
-        logging.basicConfig(filename=_filename,level=_loglevel)
+        logging.basicConfig(filename=_filename,level=_loglevel, format = "%(name)10s;%(levelname)5s;%(asctime)s;%(message)s")
     
     def __init__(self, name = None, loglevel = logging.DEBUG):
         if name is None:
@@ -58,7 +58,7 @@ class Log:
     def log(self, txt, loglevel = logging.DEBUG):
         global _include_timestamp
         if _include_timestamp:
-            txt = "(%10.3f) %s" % (eventloop.now(), txt)
+            txt = "%.3f;%s" % (eventloop.now(), txt)
         if loglevel == logging.DEBUG:
             self._logger.debug(txt)
         elif loglevel == logging.INFO:

--- a/version.py
+++ b/version.py
@@ -16,7 +16,7 @@
 # You should have received a copy of the GNU General Public License
 # along with this program.  If not, see <http://www.gnu.org/licenses/>.
 # 
-VERSION="0.23"
+VERSION="0.24"
 
 def get():
     global VERSION
@@ -24,6 +24,14 @@ def get():
 
 '''
 CHANGELOG:
+0.24    -   2016-02-19
+    Removing web.py from rpc_web, because its usage had performance issues: lots of simultaneous calls would make the server
+    to hang.
+    
+    Using the current approach enables a simple web frontend, but it should not be used as a production web server. It should
+    be used for testing purposes or simple local deployments.
+
+
 0.23    -   2016-02-02
     Setting the time of real time eventloop to absolute values, instead of local time (which were start time elapsed).
     

--- a/version.py
+++ b/version.py
@@ -31,6 +31,7 @@ CHANGELOG:
     Using the current approach enables a simple web frontend, but it should not be used as a production web server. It should
     be used for testing purposes or simple local deployments.
 
+	Logging also includes a well-known timestamp.
 
 0.23    -   2016-02-02
     Setting the time of real time eventloop to absolute values, instead of local time (which were start time elapsed).


### PR DESCRIPTION
Removing web.py from rpc_web, because its usage had performance issues: lots of simultaneous calls would make the server to hang.

Using the current approach enables a simple web frontend, but it should not be used as a production web server. It should be used for testing purposes or simple local deployments.
