### PR TITLE
Some fixes

### DIFF
--- a/config.py
+++ b/config.py
@@ -82,7 +82,7 @@ def config_filename(filename):
     _LOGGER.info("using path \"%s\" for filename \"%s\"" % (filename, filename))
     return filename
 
-def read_config(section, variables, sink, filename = None):
+def read_config(section, variables, sink, filename = None, logvars = False):
     """
         This functions creates a dictionary whose keys are the variables indicated in
         'variables' with the values obtained from the config filenames set for this module.
@@ -133,7 +133,8 @@ def read_config(section, variables, sink, filename = None):
                 
         varname = varname.upper()
         sink.__dict__[varname] = value
-        _LOGGER.debug("%s=%s" % (varname, str(value)))
+        if (logvars):
+            _LOGGER.debug("%s=%s" % (varname, str(value)))
 
 class Configuration():
     """

--- a/oneconnect.py
+++ b/oneconnect.py
@@ -45,6 +45,7 @@ class HOST(XMLObject):
     MONITORING_ERROR = 5 # Monitoring the host (from error).
     MONITORING_INIT = 6 # Monitoring the host (from init).
     MONITORING_DISABLED = 7 # Monitoring the host (from disabled).
+    OFFLINE = 8 # The host is offline
 
     ONESTATE_2_STR = {
         INIT : 'down',
@@ -54,7 +55,8 @@ class HOST(XMLObject):
         DISABLED:'down',
         MONITORING_ERROR: 'down',
         MONITORING_INIT: 'down',
-        MONITORING_DISABLED: 'down'
+        MONITORING_DISABLED: 'down',
+        OFFLINE: 'off'
     }
     
     values = [ 'ID', 'NAME', 'STATE', 'IM_MAD', 'VM_MAD', 'VN_MAD', 'CLUSTER_ID' ]
@@ -120,7 +122,9 @@ class VM(XMLObject):
     STATE_DONE      = 6
     STATE_FAILED    = 7
     STATE_POWEROFF  = 8
-    STATE_UNDEPLOYED = 9    
+    STATE_UNDEPLOYED = 9
+    STATE_CLONING = 10
+    STATE_CLONING_FAILURE = 11    
 
     # LCM_STATES
     LCM_INIT                = 0

--- a/version.py
+++ b/version.py
@@ -16,7 +16,7 @@
 # You should have received a copy of the GNU General Public License
 # along with this program.  If not, see <http://www.gnu.org/licenses/>.
 # 
-VERSION="0.27"
+VERSION="0.26"
 
 def get():
     global VERSION
@@ -24,10 +24,8 @@ def get():
 
 '''
 CHANGELOG:
-0.27    -   2017-03-22
+0.26    -   2017-03-22
     Include new states in oneconnect to avoid failing in ONE 5.2 due to KeyError (issue #10)
-
-0.26    -   2017-03-13
     Enable to dump or not configuration vars when reading.
 
 0.25	-   2016-10-06

--- a/version.py
+++ b/version.py
@@ -16,7 +16,7 @@
 # You should have received a copy of the GNU General Public License
 # along with this program.  If not, see <http://www.gnu.org/licenses/>.
 # 
-VERSION="0.26"
+VERSION="0.27"
 
 def get():
     global VERSION
@@ -24,6 +24,9 @@ def get():
 
 '''
 CHANGELOG:
+0.27    -   2017-03-22
+    Include new states in oneconnect to avoid failing in ONE 5.2 due to KeyError (issue #10)
+
 0.26    -   2017-03-13
     Enable to dump or not configuration vars when reading.
 

--- a/version.py
+++ b/version.py
@@ -16,7 +16,7 @@
 # You should have received a copy of the GNU General Public License
 # along with this program.  If not, see <http://www.gnu.org/licenses/>.
 # 
-VERSION="0.24"
+VERSION="0.26"
 
 def get():
     global VERSION
@@ -24,6 +24,9 @@ def get():
 
 '''
 CHANGELOG:
+0.26    -   2017-03-13
+    Enable to dump or not configuration vars when reading.
+
 0.25	-   2016-10-06
     Correct one bug in iputils
 


### PR DESCRIPTION
- Include new states in oneconnect to avoid failing in ONE 5.2 due to KeyError (issue #10)
- Enable to dump or not configuration vars when reading.